### PR TITLE
make new peak shape 'LorentzianSqr' available in function fitting tool

### DIFF
--- a/org.dawb.common.ui/src/org/dawb/common/ui/plot/function/FunctionType.java
+++ b/org.dawb.common.ui/src/org/dawb/common/ui/plot/function/FunctionType.java
@@ -36,6 +36,7 @@ public enum FunctionType {
 	GAUSSIAN("Gaussian"),
 //	GAUSSIAN_ND(GaussianND.class),
 	LORENTZIAN("Lorentzian"),
+	LORENTZIANSQR("LorentzianSqr"),
 //	OFFSET(Offset.class),
 	PEARSON_VII("PearsonVII"),
 	POLYNOMIAL("Polynomial"),


### PR DESCRIPTION
OK, that works for 171 - now in master it seems not :-( 
However - put LorentzianSqr here since Lorentzian is there as well