### PR TITLE
DAWNSCI-6067: Add fallback to obtain python from PATH

### DIFF
--- a/org.dawnsci.processing.python/src/uk/ac/diamond/scisoft/analysis/processing/python/AbstractPythonSavuOperation.java
+++ b/org.dawnsci.processing.python/src/uk/ac/diamond/scisoft/analysis/processing/python/AbstractPythonSavuOperation.java
@@ -20,7 +20,7 @@ public abstract class AbstractPythonSavuOperation<T extends PythonSavuModel> ext
 	public void init() {
 		
 		try {
-			s = new AnalysisRpcPythonPyDevService(false);
+			s = AnalysisRpcPythonPyDevService.create();
 			pythonRunSavuService = new PythonRunSavuService(s);
 			// can I add a plugin populator here? drop down+params list test it with a fake param. No needs to be model...
 			

--- a/org.dawnsci.processing.python/src/uk/ac/diamond/scisoft/analysis/processing/python/AbstractPythonScriptOperation.java
+++ b/org.dawnsci.processing.python/src/uk/ac/diamond/scisoft/analysis/processing/python/AbstractPythonScriptOperation.java
@@ -19,7 +19,7 @@ public abstract class AbstractPythonScriptOperation<T extends PythonScriptModel>
 	public void init() {
 		
 		try {
-			s = new AnalysisRpcPythonPyDevService(false);
+			s = AnalysisRpcPythonPyDevService.create();
 			pythonRunScriptService = new PythonRunScriptService(s);
 		} catch (Exception e) {
 			System.out.println(e);


### PR DESCRIPTION
When PyDev is not configured, and the default service is desired, add
a new entry point (createFallbackToPATH) that picks Python from the
PATH rather than prompting user or raising exception.

Signed-off-by: Jonah Graham <jonah@kichwacoders.com>